### PR TITLE
Fix for bullet graphs

### DIFF
--- a/django_geckoboard/decorators.py
+++ b/django_geckoboard/decorators.py
@@ -281,7 +281,7 @@ class BulletWidgetDecorator(WidgetDecorator):
     axis_points:    Points on the axis, eg. [0, 200, 400, 600, 800, 1000].
     current:        Current value range, eg. 500 or [100, 500]. A singleton
                     500 is internally converted to [0, 500].
-    comparitive:    Comparitive value, eg. 600.
+    comparative:    Comparative value, eg. 600.
 
     Optional keys:
     orientation:    One of 'horizontal' or 'vertical'. Defaults to horizontal.
@@ -304,7 +304,7 @@ class BulletWidgetDecorator(WidgetDecorator):
     def _convert_view_result(self, result):
         # Check required keys. We do not do type checking since this level of
         # competence is assumed.
-        for key in ('label', 'axis_points', 'current', 'comparitive'):
+        for key in ('label', 'axis_points', 'current', 'comparative'):
             if not result.has_key(key):
                 raise RuntimeError, "Key %s is required" % key
 
@@ -383,7 +383,7 @@ class BulletWidgetDecorator(WidgetDecorator):
                     green=dict(start=green[0], end=green[1])
                 ),
                 measure=dict(current=dict(start=current[0], end=current[1])),
-                comparitive=result['comparitive']
+                comparative=dict(point=result['comparative'])
             )
         )
 

--- a/django_geckoboard/tests/test_decorators.py
+++ b/django_geckoboard/tests/test_decorators.py
@@ -367,7 +367,7 @@ class BulletDecoratorTestCase(TestCase):
             'label':'Some label',
             'axis_points':[0, 200, 400, 600, 800, 1000],
             'current':500,
-            'comparitive':600,
+            'comparative':600,
             'auto_scale':False,
         }
 
@@ -385,7 +385,7 @@ class BulletDecoratorTestCase(TestCase):
         self.assertEqual(item['axis']['point'], [0, 200, 400, 600, 800, 1000])
         self.assertEqual(item['measure']['current']['start'], 0)
         self.assertEqual(item['measure']['current']['end'], 500)
-        self.assertEqual(item['comparitive'], 600)
+        self.assertEqual(item['comparative']['point'], 600)
         self.assertEqual(item['range']['red']['start'], 0)
         self.assertEqual(item['range']['red']['end'], 332)
         self.assertEqual(item['range']['amber']['start'], 333)


### PR DESCRIPTION
This is a fix for two things relating to the comparative bar on bullet graphs:
- Fix the spelling of comparative in the code
- Add a dictionary with the 'point' in it.
