### PR TITLE
Add support for Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,12 @@ python:
   - "3.4"
   - "3.5"
 
+env:
+  - DJANGO_VERSION=1.8
+  - DJANGO_VERSION=1.9
+
 install:
+  - pip install django==$DJANGO_VERSION
   - pip install .
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: python
 
 python:
+  - "2.7"
+  - "3.4"
   - "3.5"
 
 script:
-  - which python
-  - which pip
-  - python --version
   - pip install .
   - python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+
+python:
+  - "3.5"
+
+script:
+  - which python
+  - which pip
+  - python --version
+  - pip install .
+  - python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python:
   - "3.4"
   - "3.5"
 
-script:
+install:
   - pip install .
+
+script:
   - python setup.py test

--- a/django_geckoboard/decorators.py
+++ b/django_geckoboard/decorators.py
@@ -5,23 +5,17 @@ from __future__ import absolute_import
 
 from collections import OrderedDict
 from functools import wraps
+from hashlib import md5
 from xml.dom.minidom import Document
 import base64
 import json
 
-
-try:
-    from Crypto.Cipher import AES
-    from Crypto import Random
-    from hashlib import md5
-    encryption_enabled = True
-except ImportError:
-    encryption_enabled = False
-
+from Crypto import Random
+from Crypto.Cipher import AES
 from django.conf import settings
 from django.http import HttpResponse, HttpResponseForbidden
-from django.views.decorators.csrf import csrf_exempt
 from django.utils.decorators import available_attrs
+from django.views.decorators.csrf import csrf_exempt
 import six
 
 
@@ -49,12 +43,6 @@ class WidgetDecorator(object):
         obj = object.__new__(cls)
         obj._encrypted = None
         if 'encrypted' in kwargs:
-            if not encryption_enabled:
-                raise GeckoboardException(
-                    'Use of encryption requires the pycrypto package. '
-                    'This package can be installed manually or by enabling '
-                    'the encryption feature during installation.'
-                )
             obj._encrypted = kwargs.pop('encrypted')
         obj._format = None
         if 'format' in kwargs:

--- a/django_geckoboard/decorators.py
+++ b/django_geckoboard/decorators.py
@@ -51,8 +51,8 @@ class WidgetDecorator(object):
         if 'encrypted' in kwargs:
             if not encryption_enabled:
                 raise GeckoboardException(
-                    'Use of encryption requires the pycrypto package. ' + \
-                    'This package can be installed manually or by enabling ' + \
+                    'Use of encryption requires the pycrypto package. '
+                    'This package can be installed manually or by enabling '
                     'the encryption feature during installation.'
                 )
             obj._encrypted = kwargs.pop('encrypted')
@@ -527,7 +527,9 @@ def _build_list_xml(doc, parent, data):
 
 
 def _build_dict_xml(doc, parent, data):
-    for tag, item in data.items():
+    tags = sorted(data.keys())  # order tags testing ease
+    for tag in tags:
+        item = data[tag]
         if isinstance(item, (list, tuple)):
             for subitem in item:
                 elem = doc.createElement(tag)

--- a/django_geckoboard/decorators.py
+++ b/django_geckoboard/decorators.py
@@ -3,6 +3,7 @@ Geckoboard decorators.
 """
 from __future__ import absolute_import
 
+from collections import OrderedDict
 from functools import wraps
 from xml.dom.minidom import Document
 import base64
@@ -20,7 +21,6 @@ except ImportError:
 from django.conf import settings
 from django.http import HttpResponse, HttpResponseForbidden
 from django.views.decorators.csrf import csrf_exempt
-from django.utils.datastructures import SortedDict
 from django.utils.decorators import available_attrs
 import six
 
@@ -123,7 +123,7 @@ class RAGWidgetDecorator(WidgetDecorator):
         for elem in result:
             if not isinstance(elem, (tuple, list)):
                 elem = [elem]
-            item = SortedDict()
+            item = OrderedDict()
             if elem[0] is None:
                 item['value'] = ''
             else:
@@ -155,7 +155,7 @@ class TextWidgetDecorator(WidgetDecorator):
         for elem in result:
             if not isinstance(elem, (tuple, list)):
                 elem = [elem]
-            item = SortedDict()
+            item = OrderedDict()
             item['text'] = elem[0]
             if len(elem) > 1 and elem[1] is not None:
                 item['type'] = elem[1]
@@ -181,7 +181,7 @@ class PieChartWidgetDecorator(WidgetDecorator):
         for elem in result:
             if not isinstance(elem, (tuple, list)):
                 elem = [elem]
-            item = SortedDict()
+            item = OrderedDict()
             item['value'] = elem[0]
             if len(elem) > 1:
                 item['label'] = elem[1]
@@ -208,9 +208,9 @@ class LineChartWidgetDecorator(WidgetDecorator):
     """
 
     def _convert_view_result(self, result):
-        data = SortedDict()
+        data = OrderedDict()
         data['item'] = list(result[0])
-        data['settings'] = SortedDict()
+        data['settings'] = OrderedDict()
 
         if len(result) > 1:
             x_axis = result[1]
@@ -250,10 +250,10 @@ class GeckOMeterWidgetDecorator(WidgetDecorator):
 
     def _convert_view_result(self, result):
         value, min, max = result
-        data = SortedDict()
+        data = OrderedDict()
         data['item'] = value
-        data['max'] = SortedDict()
-        data['min'] = SortedDict()
+        data['max'] = OrderedDict()
+        data['min'] = OrderedDict()
 
         if not isinstance(max, (tuple, list)):
             max = [max]
@@ -290,7 +290,7 @@ class FunnelWidgetDecorator(WidgetDecorator):
     """
 
     def _convert_view_result(self, result):
-        data = SortedDict()
+        data = OrderedDict()
         items = result.get('items', [])
 
         # sort the items in order if so desired

--- a/django_geckoboard/tests/settings.py
+++ b/django_geckoboard/tests/settings.py
@@ -12,6 +12,6 @@ DATABASES = {
 INSTALLED_APPS = [
     'django_geckoboard',
 ]
-GECKOBOARD_PASSWORD = 'pass123'
+GECKOBOARD_PASSWORD = b'pass123'
 
-SECRET_KEY = 'test'
+SECRET_KEY = b'test'

--- a/django_geckoboard/tests/test_decorators.py
+++ b/django_geckoboard/tests/test_decorators.py
@@ -3,10 +3,10 @@ Tests for the Geckoboard decorators.
 """
 
 import base64
+from collections import OrderedDict
 import json
 
 from django.http import HttpRequest, HttpResponseForbidden
-from django.utils.datastructures import SortedDict
 from django_geckoboard.decorators import (
     widget, number_widget, rag_widget,
     text_widget, pie_chart, line_chart, geck_o_meter, TEXT_NONE,
@@ -135,13 +135,13 @@ class WidgetDecoratorTestCase(TestCase):
         self.assertEqual(b'"test"', resp.content)
 
     def test_dict_xml(self):
-        w = widget(lambda r: SortedDict([('a', 1), ('b', 2)]))
+        w = widget(lambda r: OrderedDict([('a', 1), ('b', 2)]))
         resp = w(self.xml_request)
         self.assertXMLEqual('<?xml version="1.0" ?><root><a>1</a><b>2</b></root>',
                             resp.content.decode('utf8'))
 
     def test_dict_json(self):
-        data = SortedDict([('a', 1), ('b', 2)])
+        data = OrderedDict([('a', 1), ('b', 2)])
         resp = widget(lambda r: data)(self.json_request)
         self.assertJSONEqual('{"a": 1, "b": 2}', resp.content.decode('utf8'))
 
@@ -166,8 +166,8 @@ class WidgetDecoratorTestCase(TestCase):
             resp.content.decode('utf8'))
 
     def test_dict_list_json(self):
-        data = [SortedDict([('value', 1), ('text', "test1")]),
-                SortedDict([('value', 2), ('text', "test2")])]
+        data = [OrderedDict([('value', 1), ('text', "test1")]),
+                OrderedDict([('value', 2), ('text', "test2")])]
         resp = widget(lambda r: {'item': data})(self.json_request)
         self.assertJSONEqual(
             ('{"item": [{"value": 1, "text": "test1"}, '

--- a/django_geckoboard/tests/test_decorators.py
+++ b/django_geckoboard/tests/test_decorators.py
@@ -26,15 +26,7 @@ def to_u(s):
     return six.text_type(s)
 
 
-class JsonCompare(object):
-    def assertSameJson(self, jsons1, jsons2):
-        jsons1 = to_u(jsons1)
-        jsons2 = to_u(jsons2)
-
-        self.assertEqual(json.loads(jsons1), json.loads(jsons2))
-
-
-class WidgetDecoratorTestCase(TestCase, JsonCompare):
+class WidgetDecoratorTestCase(TestCase):
     """
     Tests for the ``widget`` decorator.
     """
@@ -143,15 +135,15 @@ class WidgetDecoratorTestCase(TestCase, JsonCompare):
         self.assertEqual(b'"test"', resp.content)
 
     def test_dict_xml(self):
-        resp = widget(lambda r: SortedDict([('a', 1),
-                                            ('b', 2)]))(self.xml_request)
-        self.assertEqual(b'<?xml version="1.0" ?><root><a>1</a><b>2</b></root>',
-                         resp.content)
+        w = widget(lambda r: SortedDict([('a', 1), ('b', 2)]))
+        resp = w(self.xml_request)
+        self.assertXMLEqual('<?xml version="1.0" ?><root><a>1</a><b>2</b></root>',
+                            resp.content.decode('utf8'))
 
     def test_dict_json(self):
         data = SortedDict([('a', 1), ('b', 2)])
         resp = widget(lambda r: data)(self.json_request)
-        self.assertSameJson('{"a": 1, "b": 2}', resp.content)
+        self.assertJSONEqual('{"a": 1, "b": 2}', resp.content.decode('utf8'))
 
     def test_list_xml(self):
         resp = widget(lambda r: {'list': [1, 2, 3]})(self.xml_request)
@@ -162,7 +154,7 @@ class WidgetDecoratorTestCase(TestCase, JsonCompare):
 
     def test_list_json(self):
         resp = widget(lambda r: {'list': [1, 2, 3]})(self.json_request)
-        self.assertSameJson('{"list": [1, 2, 3]}', resp.content)
+        self.assertJSONEqual('{"list": [1, 2, 3]}', resp.content.decode('utf8'))
 
     def test_dict_list_xml(self):
         resp = widget(lambda r: {'item': [{'value': 1, 'text': "test1"},
@@ -177,13 +169,13 @@ class WidgetDecoratorTestCase(TestCase, JsonCompare):
         data = [SortedDict([('value', 1), ('text', "test1")]),
                 SortedDict([('value', 2), ('text', "test2")])]
         resp = widget(lambda r: {'item': data})(self.json_request)
-        self.assertSameJson(
+        self.assertJSONEqual(
             ('{"item": [{"value": 1, "text": "test1"}, '
              '{"value": 2, "text": "test2"}]}'),
-            resp.content)
+            resp.content.decode('utf8'))
 
 
-class NumberDecoratorTestCase(TestCase, JsonCompare):
+class NumberDecoratorTestCase(TestCase):
     """
     Tests for the ``number`` decorator.
     """
@@ -197,18 +189,18 @@ class NumberDecoratorTestCase(TestCase, JsonCompare):
     def test_scalar(self):
         widget = number_widget(lambda r: 10)
         resp = widget(self.request)
-        self.assertSameJson('{"item": [{"value": 10}]}', resp.content)
+        self.assertJSONEqual('{"item": [{"value": 10}]}', resp.content.decode('utf8'))
 
     def test_single_value(self):
         widget = number_widget(lambda r: [10])
         resp = widget(self.request)
-        self.assertSameJson('{"item": [{"value": 10}]}', resp.content)
+        self.assertJSONEqual('{"item": [{"value": 10}]}', resp.content.decode('utf8'))
 
     def test_single_value_and_parameter(self):
         widget = number_widget(absolute='true')(lambda r: [10])
         resp = widget(self.request)
         json = '{"item": [{"value": 10}], "absolute": "true"}'
-        self.assertSameJson(json, resp.content)
+        self.assertJSONEqual(json, resp.content.decode('utf8'))
 
     def test_single_value_and_parameter_with_format(self):
         # reset POST
@@ -216,46 +208,46 @@ class NumberDecoratorTestCase(TestCase, JsonCompare):
         widget = number_widget(absolute='true', format="json")(lambda r: [10])
         resp = widget(self.request)
         json = '{"item": [{"value": 10}], "absolute": "true"}'
-        self.assertSameJson(json, resp.content)
+        self.assertJSONEqual(json, resp.content.decode('utf8'))
 
     def test_single_value_as_dictionary(self):
         widget = number_widget(lambda r: [{'value': 10}])
         resp = widget(self.request)
         json = '{"item": [{"value": 10}]}'
-        self.assertSameJson(json, resp.content)
+        self.assertJSONEqual(json, resp.content.decode('utf8'))
 
     def test_single_value_as_dictionary_with_prefix(self):
         widget = number_widget(lambda r: [{'value': 10, 'prefix': '$'}])
         resp = widget(self.request)
         json = '{"item": [{"prefix": "$", "value": 10}]}'
-        self.assertSameJson(json, resp.content)
+        self.assertJSONEqual(json, resp.content.decode('utf8'))
 
     def test_two_values(self):
         widget = number_widget(lambda r: [10, 9])
         resp = widget(self.request)
-        self.assertSameJson('{"item": [{"value": 10}, {"value": 9}]}',
-                            resp.content)
+        self.assertJSONEqual('{"item": [{"value": 10}, {"value": 9}]}',
+                             resp.content.decode('utf8'))
 
     def test_two_values_and_parameter(self):
         widget = number_widget(absolute='true')(lambda r: [10, 9])
         resp = widget(self.request)
         json = '{"item": [{"value": 10}, {"value": 9}], "absolute": "true"}'
-        self.assertSameJson(json, resp.content)
+        self.assertJSONEqual(json, resp.content.decode('utf8'))
 
     def test_two_values_as_dictionary(self):
         widget = number_widget(lambda r: [{'value': 10}, {'value': 9}])
         resp = widget(self.request)
         json = '{"item": [{"value": 10}, {"value": 9}]}'
-        self.assertSameJson(json, resp.content)
+        self.assertJSONEqual(json, resp.content.decode('utf8'))
 
     def test_two_values_as_dictionary_with_prefix(self):
         widget = number_widget(lambda r: [{'value': 10, 'prefix': '$'}, {'value': 9}])
         resp = widget(self.request)
         json = '{"item": [{"prefix": "$", "value": 10}, {"value": 9}]}'
-        self.assertSameJson(json, resp.content)
+        self.assertJSONEqual(json, resp.content.decode('utf8'))
 
 
-class RAGDecoratorTestCase(TestCase, JsonCompare):
+class RAGDecoratorTestCase(TestCase):
     """
     Tests for the ``rag`` decorator.
     """
@@ -269,20 +261,20 @@ class RAGDecoratorTestCase(TestCase, JsonCompare):
     def test_scalars(self):
         widget = rag_widget(lambda r: (10, 5, 1))
         resp = widget(self.request)
-        self.assertSameJson(
+        self.assertJSONEqual(
             '{"item": [{"value": 10}, {"value": 5}, {"value": 1}]}',
-            resp.content)
+            resp.content.decode('utf8'))
 
     def test_tuples(self):
         widget = rag_widget(lambda r: ((10, "ten"), (5, "five"), (1, "one")))
         resp = widget(self.request)
-        self.assertSameJson(
+        self.assertJSONEqual(
             ('{"item": [{"value": 10, "text": "ten"}, '
              '{"value": 5, "text": "five"}, {"value": 1, "text": "one"}]}'),
-            resp.content)
+            resp.content.decode('utf8'))
 
 
-class TextDecoratorTestCase(TestCase, JsonCompare):
+class TextDecoratorTestCase(TestCase):
     """
     Tests for the ``text`` decorator.
     """
@@ -296,16 +288,16 @@ class TextDecoratorTestCase(TestCase, JsonCompare):
     def test_string(self):
         widget = text_widget(lambda r: "test message")
         resp = widget(self.request)
-        self.assertSameJson('{"item": [{"text": "test message", "type": 0}]}',
-                            resp.content)
+        self.assertJSONEqual('{"item": [{"text": "test message", "type": 0}]}',
+                             resp.content.decode('utf8'))
 
     def test_list(self):
         widget = text_widget(lambda r: ["test1", "test2"])
         resp = widget(self.request)
-        self.assertSameJson(
+        self.assertJSONEqual(
             ('{"item": [{"text": "test1", "type": 0}, '
              '{"text": "test2", "type": 0}]}'),
-            resp.content)
+            resp.content.decode('utf8'))
 
     def test_list_tuples(self):
         data = [("test1", TEXT_NONE),
@@ -313,14 +305,14 @@ class TextDecoratorTestCase(TestCase, JsonCompare):
                 ("test3", TEXT_WARN)]
         widget = text_widget(lambda r: data)
         resp = widget(self.request)
-        self.assertSameJson(
+        self.assertJSONEqual(
             ('{"item": [{"text": "test1", "type": 0}, '
              '{"text": "test2", "type": 2}, '
              '{"text": "test3", "type": 1}]}'),
-            resp.content)
+            resp.content.decode('utf8'))
 
 
-class PieChartDecoratorTestCase(TestCase, JsonCompare):
+class PieChartDecoratorTestCase(TestCase):
     """
     Tests for the ``pie_chart`` decorator.
     """
@@ -334,40 +326,40 @@ class PieChartDecoratorTestCase(TestCase, JsonCompare):
     def test_scalars(self):
         widget = pie_chart(lambda r: [1, 2, 3])
         resp = widget(self.request)
-        self.assertSameJson(
+        self.assertJSONEqual(
             '{"item": [{"value": 1}, {"value": 2}, {"value": 3}]}',
-            resp.content)
+            resp.content.decode('utf8'))
 
     def test_tuples(self):
         widget = pie_chart(lambda r: [(1, ), (2, ), (3, )])
         resp = widget(self.request)
-        self.assertSameJson(
+        self.assertJSONEqual(
             '{"item": [{"value": 1}, {"value": 2}, {"value": 3}]}',
-            resp.content)
+            resp.content.decode('utf8'))
 
     def test_2tuples(self):
         widget = pie_chart(lambda r: [(1, "one"), (2, "two"), (3, "three")])
         resp = widget(self.request)
-        self.assertSameJson(
+        self.assertJSONEqual(
             ('{"item": [{"value": 1, "label": "one"}, '
              '{"value": 2, "label": "two"}, '
              '{"value": 3, "label": "three"}]}'),
-            resp.content)
+            resp.content.decode('utf8'))
 
     def test_3tuples(self):
         data = [(1, "one", "00112233"),
                 (2, "two", "44556677"), (3, "three", "8899aabb")]
         widget = pie_chart(lambda r: data)
         resp = widget(self.request)
-        self.assertSameJson(
+        self.assertJSONEqual(
             ('{"item": ['
              '{"value": 1, "label": "one", "colour": "00112233"}, '
              '{"value": 2, "label": "two", "colour": "44556677"}, '
              '{"value": 3, "label": "three", "colour": "8899aabb"}]}'),
-            resp.content)
+            resp.content.decode('utf8'))
 
 
-class LineChartDecoratorTestCase(TestCase, JsonCompare):
+class LineChartDecoratorTestCase(TestCase):
     """
     Tests for the ``line_chart`` decorator.
     """
@@ -381,24 +373,24 @@ class LineChartDecoratorTestCase(TestCase, JsonCompare):
     def test_values(self):
         widget = line_chart(lambda r: ([1, 2, 3],))
         resp = widget(self.request)
-        self.assertSameJson('{"item": [1, 2, 3], "settings": {}}', resp.content)
+        self.assertJSONEqual('{"item": [1, 2, 3], "settings": {}}', resp.content.decode('utf8'))
 
     def test_x_axis(self):
         widget = line_chart(lambda r: ([1, 2, 3], ["first", "last"]))
         resp = widget(self.request)
-        self.assertSameJson(
+        self.assertJSONEqual(
             '{"item": [1, 2, 3], "settings": {"axisx": ["first", "last"]}}',
-            resp.content)
+            resp.content.decode('utf8'))
 
     def test_axes(self):
         widget = line_chart(lambda r: ([1, 2, 3],
                                        ["first", "last"],
                                        ["low", "high"]))
         resp = widget(self.request)
-        self.assertSameJson(
+        self.assertJSONEqual(
             ('{"item": [1, 2, 3], "settings": '
              '{"axisx": ["first", "last"], "axisy": ["low", "high"]}}'),
-            resp.content)
+            resp.content.decode('utf8'))
 
     def test_color(self):
         widget = line_chart(lambda r: ([1, 2, 3],
@@ -406,14 +398,14 @@ class LineChartDecoratorTestCase(TestCase, JsonCompare):
                                        ["low", "high"],
                                        "00112233"))
         resp = widget(self.request)
-        self.assertSameJson(
+        self.assertJSONEqual(
             ('{"item": [1, 2, 3], "settings": '
              '{"axisx": ["first", "last"], "axisy": ["low", "high"], '
              '"colour": "00112233"}}'),
-            resp.content)
+            resp.content.decode('utf8'))
 
 
-class GeckOMeterDecoratorTestCase(TestCase, JsonCompare):
+class GeckOMeterDecoratorTestCase(TestCase):
     """
     Tests for the ``line_chart`` decorator.
     """
@@ -427,20 +419,20 @@ class GeckOMeterDecoratorTestCase(TestCase, JsonCompare):
     def test_scalars(self):
         widget = geck_o_meter(lambda r: (2, 1, 3))
         resp = widget(self.request)
-        self.assertSameJson(
+        self.assertJSONEqual(
             '{"item": 2, "max": {"value": 3}, "min": {"value": 1}}',
-            resp.content)
+            resp.content.decode('utf8'))
 
     def test_tuples(self):
         widget = geck_o_meter(lambda r: (2, (1, "min"), (3, "max")))
         resp = widget(self.request)
-        self.assertSameJson(
+        self.assertJSONEqual(
             ('{"item": 2, "max": {"value": 3, "text": "max"}, '
              '"min": {"value": 1, "text": "min"}}'),
-            resp.content)
+            resp.content.decode('utf8'))
 
 
-class FunnelDecoratorTestCase(TestCase, JsonCompare):
+class FunnelDecoratorTestCase(TestCase):
     """
     Tests for the ``funnel`` decorator
     """
@@ -500,7 +492,7 @@ class FunnelDecoratorTestCase(TestCase, JsonCompare):
         self.assertEqual(content, expected)
 
 
-class BulletDecoratorTestCase(TestCase, JsonCompare):
+class BulletDecoratorTestCase(TestCase):
     """
     Tests for the ``bullet`` decorator
     """

--- a/django_geckoboard/tests/utils.py
+++ b/django_geckoboard/tests/utils.py
@@ -6,8 +6,9 @@ from __future__ import absolute_import
 from django.conf import settings
 from django.core.management import call_command
 from django.db.models import loading
-from django.test.utils import get_runner, setup_test_environment
 from django.test.testcases import TestCase as DjangoTestCase
+from django.test.utils import get_runner
+import django
 import six
 
 
@@ -15,7 +16,7 @@ def run_tests(labels=()):
     """
     Use the Django test runner to run the tests.
     """
-    setup_test_environment()
+    django.setup()
     TestRunner = get_runner(settings)
     test_runner = TestRunner(verbosity=1, interactive=True)
     return test_runner.run_tests(None)

--- a/django_geckoboard/tests/utils.py
+++ b/django_geckoboard/tests/utils.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 
 from django.conf import settings
 from django.core.management import call_command
-from django.db.models import loading
 from django.test.testcases import TestCase as DjangoTestCase
 from django.test.utils import get_runner
 import django
@@ -70,7 +69,6 @@ class TestSettingsManager(object):
                 pass  # setting did not exist
 
     def syncdb(self):
-        loading.cache.loaded = False
         call_command('syncdb', verbosity=0, interactive=False)
 
     def revert(self):

--- a/django_geckoboard/tests/utils.py
+++ b/django_geckoboard/tests/utils.py
@@ -1,12 +1,14 @@
 """
 Testing utilities.
 """
+from __future__ import absolute_import
 
 from django.conf import settings
 from django.core.management import call_command
 from django.db.models import loading
 from django.test.utils import get_runner, setup_test_environment
 from django.test.testcases import TestCase as DjangoTestCase
+import six
 
 
 def run_tests(labels=()):
@@ -50,9 +52,9 @@ class TestSettingsManager(object):
         self._original_settings = {}
 
     def set(self, **kwargs):
-        for k, v in kwargs.iteritems():
+        for k, v in six.iteritems(kwargs):
             self._original_settings.setdefault(k, getattr(settings, k,
-                    self.NO_SETTING))
+                                                          self.NO_SETTING))
             setattr(settings, k, v)
         if 'INSTALLED_APPS' in kwargs:
             self.syncdb()
@@ -61,7 +63,7 @@ class TestSettingsManager(object):
         for k in args:
             try:
                 self._original_settings.setdefault(k, getattr(settings, k,
-                        self.NO_SETTING))
+                                                              self.NO_SETTING))
                 delattr(settings, k)
             except AttributeError:
                 pass  # setting did not exist
@@ -71,7 +73,7 @@ class TestSettingsManager(object):
         call_command('syncdb', verbosity=0, interactive=False)
 
     def revert(self):
-        for k,v in self._original_settings.iteritems():
+        for k, v in six.iteritems(self._original_settings):
             if v == self.NO_SETTING:
                 if hasattr(settings, k):
                     delattr(settings, k)

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
-from setuptools import setup, Command
 import os
+import sys
+
+from setuptools import setup, Command
 
 import django_geckoboard
 
@@ -22,7 +24,9 @@ class TestCommand(Command):
 
     def run(self):
         from django_geckoboard.tests.utils import run_tests
-        run_tests()
+        errors = run_tests()
+        if errors:
+            sys.exit(1)
 
 cmdclass['test'] = TestCommand
 

--- a/setup.py
+++ b/setup.py
@@ -50,10 +50,7 @@ setup(
         'django_geckoboard',
         'django_geckoboard.tests',
     ],
-    install_requires=['six', 'django'],
-    extras_require={
-        'encryption': ['pycrypto']
-    },
+    install_requires=['six', 'django', 'pycrypto'],
     keywords=['django', 'geckoboard'],
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ os.environ['DJANGO_SETTINGS_MODULE'] = 'django_geckoboard.tests.settings'
 
 cmdclass = {}
 
+
 class TestCommand(Command):
     description = "run package tests"
     user_options = []
@@ -29,30 +30,32 @@ cmdclass['test'] = TestCommand
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
+
 def build_long_description():
     return "\n\n".join([
-        django_geckoboard.__doc__,  #@UndefinedVariable
+        django_geckoboard.__doc__,
         read('CHANGELOG.rst'),
     ])
 
 
 setup(
-    name = 'django-geckoboard',
-    version = django_geckoboard.__version__,
-    license = django_geckoboard.__license__,
-    description = 'Geckoboard custom widgets for Django projects',
-    long_description = build_long_description(),
-    author = django_geckoboard.__author__,
-    author_email = django_geckoboard.__email__,
-    packages = [
+    name='django-geckoboard',
+    version=django_geckoboard.__version__,
+    license=django_geckoboard.__license__,
+    description='Geckoboard custom widgets for Django projects',
+    long_description=build_long_description(),
+    author=django_geckoboard.__author__,
+    author_email=django_geckoboard.__email__,
+    packages=[
         'django_geckoboard',
         'django_geckoboard.tests',
     ],
-    extras_require = {
+    install_requires=['six', 'django'],
+    extras_require={
         'encryption': ['pycrypto']
     },
-    keywords = ['django', 'geckoboard'],
-    classifiers = [
+    keywords=['django', 'geckoboard'],
+    classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',
         'Framework :: Django',
@@ -63,8 +66,8 @@ setup(
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
-    platforms = ['any'],
-    url = 'http://github.com/jcassee/django-geckoboard',
-    download_url = 'http://github.com/jcassee/django-geckoboard/archives/master',
-    cmdclass = cmdclass,
+    platforms=['any'],
+    url='http://github.com/jcassee/django-geckoboard',
+    download_url='http://github.com/jcassee/django-geckoboard/archives/master',
+    cmdclass=cmdclass,
 )


### PR DESCRIPTION
Drops support for python 2.4, 2.5, and 2.6.  Adds explicit support for python 2.7, 3.4, and 3.5 on Django 1.8 and Django 1.9.  Older versions of Django will probably work, but the test suite doesn't.

Also adds .travis.yml for CI.  Just enable travis for the repo.