### PR TITLE
Sorry Éric

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,7 +39,7 @@ Version 1.2.2
 
 Version 1.2.1
 -------------
-* Fix unicode handling (Éric St-Jean)
+* Fix unicode handling (Eric St-Jean)
 
 Version 1.2.0
 -------------


### PR DESCRIPTION
looks like my python3.4 doen't likes Éric's name

```
Downloading/unpacking django-geckoboard==2.0.0 (from -r requirements.txt (line 8))
Downloading django-geckoboard-2.0.0.tar.gz
Running setup.py (path:/tmp/pip-build-1stk4p_a/django-geckoboard/setup.py) egg_info for package django-geckoboard
Traceback (most recent call last):
File "<string>", line 17, in <module>
File "/tmp/pip-build-1stk4p_a/django-geckoboard/setup.py", line 50, in <module>
long_description=build_long_description(),
File "/tmp/pip-build-1stk4p_a/django-geckoboard/setup.py", line 41, in build_long_description
read('CHANGELOG.rst'),
File "/tmp/pip-build-1stk4p_a/django-geckoboard/setup.py", line 35, in read
return open(os.path.join(os.path.dirname(__file__), fname)).read()
File "/opt/rh/rh-python34/root/usr/lib64/python3.4/encodings/ascii.py", line 26, in decode
return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 877: ordinal not in range(128)
Complete output from command python setup.py egg_info:
Traceback (most recent call last):

File "<string>", line 17, in <module>

File "/tmp/pip-build-1stk4p_a/django-geckoboard/setup.py", line 50, in <module>

long_description=build_long_description(),

File "/tmp/pip-build-1stk4p_a/django-geckoboard/setup.py", line 41, in build_long_description

read('CHANGELOG.rst'),

File "/tmp/pip-build-1stk4p_a/django-geckoboard/setup.py", line 35, in read

return open(os.path.join(os.path.dirname(__file__), fname)).read()

File "/opt/rh/rh-python34/root/usr/lib64/python3.4/encodings/ascii.py", line 26, in decode

return codecs.ascii_decode(input, self.errors)[0]

UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 877: ordinal not in range(128)
```
